### PR TITLE
Add Azure DevOps Pipelines Sample

### DIFF
--- a/pipelines/deploy-pf-online-endpoint-pipeline.yml
+++ b/pipelines/deploy-pf-online-endpoint-pipeline.yml
@@ -1,0 +1,120 @@
+trigger: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  - group: web-classification
+
+stages:
+  - stage: Deploy
+    jobs:
+      - job: Deploy
+        steps:
+          - script: |
+             az extension add -n ml -y --allow-preview true
+            displayName: "Install az ml extension"
+
+          - script: |
+             ls
+            displayName: "List current directory"
+
+          - task: AzureCLI@2
+            displayName: Create endpoint if not exist
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                ENDPOINT=$(Endpoint)
+                echo "Endpoint is $ENDPOINT"
+                endpoints=$(az ml online-endpoint list -g "$(ResourceGroup)" -w "$(Workspace)")
+                echo $endpoints
+                if echo "$endpoints" | jq -e --arg ENDPOINT "$ENDPOINT" '.[] | select(.name == $ENDPOINT)' > /dev/null; then
+                    echo "The endpoint '$ENDPOINT' exists."
+                else
+                    echo "Creating the endpoint '$ENDPOINT'"
+                    FILE_PATH="promptflow/deployment/endpoint.yaml"
+                    EP_OBJ_ID=$(az ml online-endpoint create --file $FILE_PATH --name $(Endpoint) -g $(ResourceGroup) -w $(Workspace) | jq -r '.identity.principal_id')
+                    echo "Endpoint object ID is $EP_OBJ_ID"
+                    az role assignment create --assignee-object-id $EP_OBJ_ID --assignee-principal-type "ServicePrincipal" --role "Azure Machine Learning Workspace Connection Secrets Reader" --scope "/subscriptions/$(SUBSCRIPTION)/resourceGroups/$(ResourceGroup)/providers/Microsoft.MachineLearningServices/workspaces/$(Workspace)"
+                fi
+          - task: AzureCLI@2
+            displayName: Create model
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                FILE_PATH="promptflow/deployment/model.yaml"
+                output=$(az ml model create --file $FILE_PATH -g $(ResourceGroup) -w $(WORKSPACE))
+                NAME=$(echo "$output" | jq -r '.name')
+                VERSION=$(echo "$output" | jq -r '.version')
+                ML_MODEL_NAME="azureml:$NAME:$VERSION"
+                echo "ML_MODEL_NAME is $ML_MODEL_NAME"
+                echo "##vso[task.setvariable variable=MODEL_NAME]$ML_MODEL_NAME"
+                
+          - task: AzureCLI@2
+            displayName: Create deployment
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                PRT_CONFIG_OVERRIDE=deployment.subscription_id=$(SUBSCRIPTION),deployment.resource_group=$(ResourceGroup),deployment.workspace_name=$(WORKSPACE),deployment.endpoint_name=$(Endpoint),deployment.deployment_name=$(Deployment)
+                echo $PRT_CONFIG_OVERRIDE
+                FILE_PATH="promptflow/deployment/deployment.yaml"
+
+                sed -i "s/PRT_CONFIG_OVERRIDE:.*/PRT_CONFIG_OVERRIDE: $PRT_CONFIG_OVERRIDE/g" "$FILE_PATH"
+
+                if grep -q "PRT_CONFIG_OVERRIDE: $PRT_CONFIG_OVERRIDE" "$FILE_PATH"; then
+                    echo "PRT_CONFIG_OVERRIDE was successfully updated to '$PRT_CONFIG_OVERRIDE' in the file '$FILE_PATH'."
+                else
+                    echo "Failed to update PRT_CONFIG_OVERRIDE in the file '$FILE_PATH'."
+                fi
+
+                sed -i "s/^model: .*/model: $MODEL_NAME/" "$FILE_PATH"
+                if grep -q "^model: $MODEL_NAME" "$FILE_PATH"; then
+                    echo "Model name was successfully updated to '$MODEL_NAME' in the file '$FILE_PATH'."
+                else
+                    echo "Failed to update model name in the file '$FILE_PATH'."
+                fi
+
+                echo "Checking if deployment $(Deployment) exists..."
+                deployment_exists=$(az ml online-deployment show --name $(Deployment) --endpoint-name $(Endpoint) -g $(ResourceGroup) -w $(WORKSPACE) --query "name" -o tsv)
+
+                if [ -z "$deployment_exists" ]; then
+                    echo "Deployment $(Deployment) does not exist. Creating deployment..."
+                    az ml online-deployment create --file $FILE_PATH --endpoint-name $(Endpoint) --name $(Deployment) --all-traffic -g $(ResourceGroup) -w $(WORKSPACE)
+                else
+                    echo "Deployment $(Deployment) exists. Updating deployment..."
+                    az ml online-deployment update --file $FILE_PATH --endpoint-name $(Endpoint) --name $(Deployment) -g $(ResourceGroup) -w $(WORKSPACE)
+                fi
+             
+          - task: AzureCLI@2
+            displayName: Check the status of the endpoint
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az ml online-endpoint show -n $(Endpoint) -g $(ResourceGroup) -w $(WORKSPACE)
+
+          - task: AzureCLI@2
+            displayName: Check the status of the deployment
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az ml online-deployment get-logs -e $(Endpoint) -n $(Deployment) -g $(ResourceGroup) -w $(WORKSPACE)
+
+          - task: AzureCLI@2
+            displayName: Invoke model
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az ml online-endpoint invoke --name $(Endpoint) --request-file promptflow/deployment/sample-request.json  -g $(ResourceGroup) -w $(WORKSPACE)    
+

--- a/pipelines/run-eval-pf-pipeline.yml
+++ b/pipelines/run-eval-pf-pipeline.yml
@@ -1,0 +1,113 @@
+trigger: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  - group: web-classification
+
+stages:
+  - stage: Evaluate
+    jobs:
+      - job: Evaluate
+        steps:
+          - task: UsePythonVersion@0
+            displayName: 'Use Python 3.9'
+            inputs:
+              versionSpec: '3.9'
+
+          - script: |
+             ls
+            displayName: "List current directory"
+
+          - script: |
+             pip install -r promptflow/web-classification/requirements.txt
+            displayName: "Install promptflow"
+
+          - task: AzureCLI@2
+            displayName: Run promptflow
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                pfazure run create -f promptflow/web-classification/run.yml --subscription $(Subscription) -g $(ResourceGroup) -w $(Workspace) --stream > promptflow/llmops-helper/run_info.txt
+                cat promptflow/llmops-helper/run_info.txt
+
+          - script: |
+                RUN_NAME=$(python promptflow/llmops-helper/parse_run_output.py run_info.txt)
+                echo "##vso[task.setvariable variable=RUN_NAME]$RUN_NAME"
+                echo "Run name is: $RUN_NAME"
+            displayName: "Set run name"
+
+          - task: AzureCLI@2
+            displayName: Show promptflow results
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                pfazure run show-details --name $(RUN_NAME) --subscription $(Subscription) -g $(ResourceGroup) -w $(Workspace)
+
+          - task: AzureCLI@2
+            displayName: Run promptflow evaluations
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                pfazure run create -f promptflow/web-classification/run_evaluation.yml --run $(RUN_NAME) --subscription $(Subscription) -g $(ResourceGroup) -w $(Workspace) --stream > promptflow/llmops-helper/eval_info.txt
+
+          - script: |
+                EVAL_RUN_NAME=$(python promptflow/llmops-helper/parse_run_output.py eval_info.txt)
+                echo "##vso[task.setvariable variable=EVAL_RUN_NAME]$EVAL_RUN_NAME"
+                echo "Eval run name is: $EVAL_RUN_NAME"
+            displayName: "Set eval run name"
+
+          - task: AzureCLI@2
+            displayName: Show promptflow details
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                pfazure run show-details --name $(EVAL_RUN_NAME) --subscription $(Subscription) -g $(ResourceGroup) -w $(Workspace)
+
+          - task: AzureCLI@2
+            displayName: Show promptflow metrics
+            inputs:
+              azureSubscription: 'AzureConnection'
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                pfazure run show-metrics --name $(EVAL_RUN_NAME) --subscription $(Subscription) -g $(ResourceGroup) -w $(Workspace) > promptflow/llmops-helper/eval_result.json
+                cat promptflow/llmops-helper/eval_result.json
+
+      - job: Assert
+        dependsOn: Evaluate
+        steps:
+          - task: UsePythonVersion@0
+            displayName: 'Use Python 3.9'
+            inputs:
+              versionSpec: '3.9'
+
+          - script: |
+             ls
+            displayName: "List current directory"
+
+          - script: |
+             pip install -r promptflow/web-classification/requirements.txt
+            displayName: "Install promptflow"
+
+          - script: |
+             export ASSERT=$(python promptflow/llmops-helper/assert.py result.json 0.6) # NOTE <file>.json is the file name and decimal is the threshold for the assertion
+             echo "::debug::Assert has returned the following value: $ASSERT"
+             # assert.py will return True or False, but bash expects lowercase.
+             if ${ASSERT,,} ; then
+               echo "::debug::Prompt flow run met the quality bar and can be deployed."
+               echo "::set-output name=result::true"
+             else
+               echo "::warning::Prompt flow run didn't meet quality bar."
+               echo "::set-output name=result::false"
+             fi
+            displayName: "Get assert eval results"

--- a/promptflow/web-classification/run_evaluation.yml
+++ b/promptflow/web-classification/run_evaluation.yml
@@ -9,10 +9,10 @@ column_mapping:
 # define cloud resource
 runtime: automatic
 
-connections:
-  classify_with_llm:
-    connection: Default_AzureOpenAI
-    deployment_name: gpt-35-turbo-0301
-  summarize_text_content:
-    connection: Default_AzureOpenAI
-    deployment_name: gpt-35-turbo-0301
+# connections:
+#   classify_with_llm:
+#     connection: Default_AzureOpenAI
+#     deployment_name: gpt-35-turbo-0301
+#   summarize_text_content:
+#     connection: Default_AzureOpenAI
+#     deployment_name: gpt-35-turbo-0301


### PR DESCRIPTION
# Description
Hi, @setuc cc: @satonaoki
Thank you for providing this sample. We referred to the GitHub Actions pipelines and implemented our own evaluation and deployment pipeline in our project. Since we used Azure DevOps (ADO) pipelines, I would like to contribute an ADO pipelines sample back.  I have two questions:

1. Since the name of the repo is llmops-gha-demo, do you think it's appropriate to contribute ADO pipelines sample to this repo? If you have other suggestions, please let me know.
2. If we can contribute an ADO pipelines sample to this repo, should we also add documentation for ADO pipelines similar to the GitHub Actions documentation here: https://github.com/Azure/llmops-gha-demo/blob/main/docs/e2e_llmops_with_promptflow.md

Thank you in advance.

# Changes
Add ADO prompt flow evaluation and deployment pipeline samples deploy-pf-online-endpoint-pipeline and run-eval-pf-pipeline.

# How Has This Been Tested?
Tested in ADO pipelines.
## Evaluation
<img width="273" alt="Screenshot 2024-08-02 at 13 31 34" src="https://github.com/user-attachments/assets/bedc3205-2768-4285-b678-0b8e96b920c8">

## Deployment
<img width="291" alt="Screenshot 2024-08-02 at 13 32 10" src="https://github.com/user-attachments/assets/abebce15-4fa8-4276-a702-f6775b5f6a52">
